### PR TITLE
배포단계 타임아웃 300초로 연장

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -15,11 +15,11 @@ hooks:
   AfterInstall:
   ApplicationStart:
     - location: scripts/run.sh
-      timeout: 100
+      timeout: 300
       runas: ubuntu
     - location: scripts/healthcheck.sh
-      timeout: 100
+      timeout: 300
       runas: ubuntu
     - location: scripts/switch.sh
-      timeout: 100
+      timeout: 300
       runas: ubuntu


### PR DESCRIPTION
appspec.yml의 timeout 값을 100초에서 300초로 늘렸습니다.
