### PR TITLE
배포 로그파일 분리

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,6 +17,9 @@ TARGET_PORT=0
 # 포트번호 변경
 if [ $CURRENT_PORT -eq 8081 ]; then
   TARGET_PORT=8082
+  DEPLOY_LOG="$PROJECT_ROOT/deploy2.log"
+  APP_LOG="$PROJECT_ROOT/application2.log"
+  ERROR_LOG="$PROJECT_ROOT/error2.log"
 elif [ $CURRENT_PORT -eq 8082 ]; then
   TARGET_PORT=8081
 else

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -9,6 +9,7 @@ TARGET_PORT=0
 
 if [ $CURRENT_PORT -eq 8081 ]; then
   TARGET_PORT=8082
+  DEPLOY_LOG="$PROJECT_ROOT/deploy2.log"
 elif [ $CURRENT_PORT -eq 8082 ]; then
   TARGET_PORT=8081
 else


### PR DESCRIPTION
문제상황
- 이전 배포서버에서 log 텍스트 파일과 새로 뜨는 서버의 log 텍스트 파일이 같음

해결
- 이전 서버/새 서버의 log 파일을 분리하여 안정성 높임
