### PR TITLE
refactor : dto 변수 이름 변경 및 메서드 리팩터링

### DIFF
--- a/src/main/java/com/example/chillisauce/reservations/controller/ReservationController.java
+++ b/src/main/java/com/example/chillisauce/reservations/controller/ReservationController.java
@@ -1,10 +1,10 @@
 package com.example.chillisauce.reservations.controller;
 
 import com.example.chillisauce.message.ResponseMessage;
-import com.example.chillisauce.reservations.dto.request.ReservationRequestDto;
-import com.example.chillisauce.reservations.dto.response.ReservationListResponseDto;
-import com.example.chillisauce.reservations.dto.response.ReservationResponseDto;
-import com.example.chillisauce.reservations.dto.response.ReservationTimetableResponseDto;
+import com.example.chillisauce.reservations.dto.request.ReservationRequest;
+import com.example.chillisauce.reservations.dto.response.ReservationListResponse;
+import com.example.chillisauce.reservations.dto.response.ReservationResponse;
+import com.example.chillisauce.reservations.dto.response.ReservationTimetableResponse;
 import com.example.chillisauce.reservations.service.ReservationService;
 import com.example.chillisauce.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,7 +34,7 @@ public class ReservationController {
     @Operation(summary = "전체 예약 조회",
             description = "특정 회의실의 특정 날짜 예약 내역을 타임단위로 조회합니다.")
     @GetMapping("/reservations/{companyName}/all")
-    public ResponseEntity<ResponseMessage<ReservationListResponseDto>> getAllReservations(
+    public ResponseEntity<ResponseMessage<ReservationListResponse>> getAllReservations(
             @Parameter(description = "회사 이름", required = true, example = "testCompany")
             @PathVariable String companyName,
             @Parameter(hidden = true)
@@ -50,7 +50,7 @@ public class ReservationController {
     @Operation(summary = "예약 타임테이블 조회",
             description = "특정 회의실의 특정 날짜 예약 내역을 타임단위로 조회합니다.")
     @GetMapping("/reservations/{meetingRoomId}")
-    public ResponseEntity<ResponseMessage<ReservationTimetableResponseDto>> getReservationTimetable(
+    public ResponseEntity<ResponseMessage<ReservationTimetableResponse>> getReservationTimetable(
             @Parameter(description = "선택날짜", example = "2023-04-10")
             @RequestParam(value = "selDate", required = false, defaultValue = "#{T(java.time.LocalDate).now()}")
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate selDate,
@@ -68,13 +68,13 @@ public class ReservationController {
     @Operation(summary = "예약 등록",
             description = "특정 회의실에 예약을 등록합니다. DB에 등록된 회의실의 id값이 필요합니다.")
     @PostMapping("/reservations/{meetingRoomId}")
-    public ResponseEntity<ResponseMessage<ReservationResponseDto>> addReservation(
+    public ResponseEntity<ResponseMessage<ReservationResponse>> addReservation(
             @Parameter(description = "회의실 id 값", required = true, example = "3")
             @PathVariable Long meetingRoomId,
-            @RequestBody @Valid ReservationRequestDto requestDto,
+            @RequestBody @Valid ReservationRequest request,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseMessage
-                .responseSuccess("예약 등록 성공", reservationService.addReservation(meetingRoomId, requestDto, userDetails));
+                .responseSuccess("예약 등록 성공", reservationService.addReservation(meetingRoomId, request, userDetails));
     }
 
     /**
@@ -83,13 +83,13 @@ public class ReservationController {
     @Operation(summary = "예약 수정",
             description = "회원 자신이 등록한 예약을 수정합니다. DB에 등록된 예약의 id값이 필요합니다.")
     @PatchMapping("/reservations/{reservationId}")
-    public ResponseEntity<ResponseMessage<ReservationResponseDto>> editReservation(
+    public ResponseEntity<ResponseMessage<ReservationResponse>> editReservation(
             @Parameter(description = "예약 id 값", required = true, example = "3")
             @PathVariable Long reservationId,
-            @RequestBody @Valid ReservationRequestDto requestDto,
+            @RequestBody @Valid ReservationRequest request,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseMessage
-                .responseSuccess("예약 수정 성공", reservationService.editReservation(reservationId, requestDto, userDetails));
+                .responseSuccess("예약 수정 성공", reservationService.editReservation(reservationId, request, userDetails));
     }
 
     /**

--- a/src/main/java/com/example/chillisauce/reservations/controller/UserReservationController.java
+++ b/src/main/java/com/example/chillisauce/reservations/controller/UserReservationController.java
@@ -1,7 +1,7 @@
 package com.example.chillisauce.reservations.controller;
 
 import com.example.chillisauce.message.ResponseMessage;
-import com.example.chillisauce.reservations.dto.response.UserReservationListResponseDto;
+import com.example.chillisauce.reservations.dto.response.UserReservationListResponse;
 import com.example.chillisauce.reservations.service.UserReservationService;
 import com.example.chillisauce.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class UserReservationController {
      * 회원의 예약 전체 조회
      */
     @GetMapping("/users/reservations")
-    public ResponseEntity<ResponseMessage<UserReservationListResponseDto>> getUserReservations(@AuthenticationPrincipal UserDetailsImpl userDetails){
+    public ResponseEntity<ResponseMessage<UserReservationListResponse>> getUserReservations(@AuthenticationPrincipal UserDetailsImpl userDetails){
         return ResponseMessage
                 .responseSuccess("회원의 예약 조회 성공", userReservationService.getUserReservations(userDetails));
     }

--- a/src/main/java/com/example/chillisauce/reservations/dto/request/ReservationRequest.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/request/ReservationRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ReservationRequestDto {
+public class ReservationRequest {
     @NotEmpty(message = "요청의 시각 목록이 비어있습니다.")
     List<ReservationTime> startList;
     List<ReservationAttendee> userList;

--- a/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationDetailResponse.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationDetailResponse.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class ReservationDetailResponseDto {
+public class ReservationDetailResponse {
     Long reservationId;
     Long mrId;
     String mrName;
@@ -24,16 +24,7 @@ public class ReservationDetailResponseDto {
     LocalDateTime end;
 //    List<String> userList;
 
-    public ReservationDetailResponseDto(Reservation reservation) {
-        this.reservationId= reservation.getId();
-        this.mrName=reservation.getMeetingRoom().getLocationName();
-        this.mrId=reservation.getMeetingRoom().getId();
-        this.username=reservation.getUser().getUsername();
-        this.start=reservation.getStartTime();
-        this.end=reservation.getEndTime();
-    }
-
-    public ReservationDetailResponseDto(Reservation reservation, Long mrId, String username) {
+    public ReservationDetailResponse(Reservation reservation, Long mrId, String username) {
         this.reservationId= reservation.getId();
         this.mrId=mrId;
         this.mrName=reservation.getMeetingRoom().getLocationName();

--- a/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationListResponse.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationListResponse.java
@@ -9,6 +9,6 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class ReservationListResponseDto {
-    List<ReservationDetailResponseDto> reservationList;
+public class ReservationListResponse {
+    List<ReservationDetailResponse> reservationList;
 }

--- a/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationResponse.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationResponse.java
@@ -12,20 +12,20 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class ReservationResponseDto {
+public class ReservationResponse {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
     LocalDateTime start;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
     LocalDateTime end;
-    List<UsernameResponseDto> userList;
+    List<UsernameResponse> userList;
 
-    public ReservationResponseDto(Reservation reservation){
+    public ReservationResponse(Reservation reservation){
         this.start = reservation.getStartTime();
         this.end = reservation.getEndTime();
     }
 
-    public ReservationResponseDto(Reservation reservation, List<UsernameResponseDto> userList) {
+    public ReservationResponse(Reservation reservation, List<UsernameResponse> userList) {
         this.start = reservation.getStartTime();
         this.end = reservation.getEndTime();
         this.userList = userList;

--- a/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationTimeResponse.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationTimeResponse.java
@@ -2,7 +2,6 @@ package com.example.chillisauce.reservations.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +16,7 @@ import java.time.LocalTime;
 @Getter
 @NoArgsConstructor
 @Schema(description = "예약 타임테이블 시각 단위 응답 DTO")
-public class ReservationTimeResponseDto {
+public class ReservationTimeResponse {
     @Schema(description = "해당 시각 예약 여부")
     Boolean isCheckOut;
 
@@ -30,7 +29,7 @@ public class ReservationTimeResponseDto {
     LocalTime end;
 
     @Builder
-    public ReservationTimeResponseDto(Boolean isCheckOut, LocalTime start, LocalTime end) {
+    public ReservationTimeResponse(Boolean isCheckOut, LocalTime start, LocalTime end) {
         this.isCheckOut = isCheckOut;
         this.start = LocalTime.of(start.getHour(), start.getMinute());
         this.end = LocalTime.of(end.getHour(), end.getMinute());

--- a/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationTimetableResponse.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/response/ReservationTimetableResponse.java
@@ -12,11 +12,11 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @Schema(description = "예약 타임테이블 응답 DTO")
-public class ReservationTimetableResponseDto {
+public class ReservationTimetableResponse {
     @Schema(description = "회의실 Id")
     Long mrId;
     @Schema(description = "회의실 이름")
     String mrName;
     @Schema(description = "타임테이블 리스트")
-    List<ReservationTimeResponseDto> timeList;
+    List<ReservationTimeResponse> timeList;
 }

--- a/src/main/java/com/example/chillisauce/reservations/dto/response/UserReservationListResponse.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/response/UserReservationListResponse.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class UserReservationListResponseDto {
-    List<UserReservationResponseDto> reservationList;
+public class UserReservationListResponse {
+    List<UserReservationResponse> reservationList;
 }

--- a/src/main/java/com/example/chillisauce/reservations/dto/response/UserReservationResponse.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/response/UserReservationResponse.java
@@ -16,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Schema(description = "유저 예약 정보 응답 DTO")
-public class UserReservationResponseDto {
+public class UserReservationResponse {
     @Schema(description = "예약 id")
     Long reservationId;
     @Schema(description = "회의실 id")
@@ -35,9 +35,9 @@ public class UserReservationResponseDto {
     LocalDateTime end;
 
     @Schema(description = "참석자 목록")
-    List<UsernameResponseDto> userList;
+    List<UsernameResponse> userList;
 
-    public UserReservationResponseDto(Reservation reservation) {
+    public UserReservationResponse(Reservation reservation) {
         this.reservationId = reservation.getId();
         this.mrId = reservation.getMeetingRoom().getId();
         this.mrName=reservation.getMeetingRoom().getLocationName();
@@ -46,7 +46,7 @@ public class UserReservationResponseDto {
         this.end = reservation.getEndTime();
     }
 
-    public UserReservationResponseDto(Reservation reservation, Long mrId, String username, List<UsernameResponseDto> userList) {
+    public UserReservationResponse(Reservation reservation, Long mrId, String username, List<UsernameResponse> userList) {
         this.reservationId = reservation.getId();
         this.mrId = mrId;
         this.mrName=reservation.getMeetingRoom().getLocationName();

--- a/src/main/java/com/example/chillisauce/reservations/dto/response/UsernameResponse.java
+++ b/src/main/java/com/example/chillisauce/reservations/dto/response/UsernameResponse.java
@@ -8,10 +8,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class UsernameResponseDto {
+public class UsernameResponse {
     String username;
 
-    public UsernameResponseDto(ReservationUserWrapper dto){
+    public UsernameResponse(ReservationUserWrapper dto){
         username = dto.getUsername();
     }
 }

--- a/src/main/java/com/example/chillisauce/reservations/service/ReservationService.java
+++ b/src/main/java/com/example/chillisauce/reservations/service/ReservationService.java
@@ -1,6 +1,6 @@
 package com.example.chillisauce.reservations.service;
 
-import com.example.chillisauce.reservations.dto.request.ReservationRequestDto;
+import com.example.chillisauce.reservations.dto.request.ReservationRequest;
 import com.example.chillisauce.reservations.dto.request.ReservationTime;
 import com.example.chillisauce.reservations.dto.request.ReservationAttendee;
 import com.example.chillisauce.reservations.dto.response.*;
@@ -11,6 +11,7 @@ import com.example.chillisauce.reservations.exception.ReservationException;
 import com.example.chillisauce.reservations.repository.ReservationRepository;
 import com.example.chillisauce.reservations.repository.ReservationUserRepository;
 import com.example.chillisauce.reservations.vo.ReservationTimetable;
+import com.example.chillisauce.reservations.vo.TimeUnit;
 import com.example.chillisauce.schedules.entity.Schedule;
 import com.example.chillisauce.schedules.repository.ScheduleRepository;
 import com.example.chillisauce.security.UserDetailsImpl;
@@ -46,18 +47,19 @@ public class ReservationService {
     /**
      * 회사 전체 예약 조회
      */
-    public ReservationListResponseDto getAllReservations(String companyName, UserDetailsImpl userDetails) {
+    public ReservationListResponse getAllReservations(String companyName, UserDetailsImpl userDetails) {
         Companies companies = companyRepository.findByCompanyName(companyName)
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.COMPANY_NOT_FOUND));
 
         List<Reservation> all = reservationRepository.findAll();
 
-        return new ReservationListResponseDto(all.stream().map(x -> {
+        // 회의실이 null, 유저가 null : 삭제된 객체
+        return new ReservationListResponse(all.stream().map(x -> {
             Mr meetingRoom = x.getMeetingRoom();
             User user = x.getUser();
             Long mrId = meetingRoom == null ? 0 : meetingRoom.getId();
             String username = user == null ? "탈퇴한 유저" : user.getUsername();
-            return new ReservationDetailResponseDto(x, mrId, username);
+            return new ReservationDetailResponse(x, mrId, username);
         }).toList());
     }
 
@@ -65,26 +67,13 @@ public class ReservationService {
      * 타임테이블 조회
      */
     @Transactional(readOnly = true)
-    public ReservationTimetableResponseDto getReservationTimetable(LocalDate selDate,
-                                                                   Long meetingRoomId,
-                                                                   UserDetailsImpl userDetails) {
+    public ReservationTimetableResponse getReservationTimetable(LocalDate selDate,
+                                                                Long meetingRoomId,
+                                                                UserDetailsImpl userDetails) {
         Mr meetingRoom = meetingRoomRepository.findById(meetingRoomId).orElseThrow(
                 () -> new ReservationException(ReservationErrorCode.MEETING_ROOM_NOT_FOUND));
 
         User user = userDetails.getUser();
-
-        // 오늘 날짜 이전이면 모두 true 처리
-        if (selDate.isBefore(LocalDate.now())) {
-            List<ReservationTimeResponseDto> timeList = ReservationTimetable.TIME_SET.stream().map(
-                    x -> {
-                        LocalTime startTime = LocalTime.of(x.getStart().getHour(), x.getStart().getMinute());
-                        LocalTime endTime = LocalTime.of(x.getEnd().getHour(), x.getEnd().getMinute());
-                        return new ReservationTimeResponseDto(true, startTime, endTime);
-                    }).sorted(((o1, o2) -> o1.getStart().isAfter(o2.getStart()) ? 1 :
-                            o1.getStart().isBefore(o2.getStart()) ? -1 : 0))
-                    .toList();
-            return new ReservationTimetableResponseDto(meetingRoom.getId(), meetingRoom.getLocationName(), timeList);
-        }
 
         // 회의실의 해당 날짜에 해당하는 모든 예약 리스트
         List<Reservation> all = reservationRepository
@@ -92,24 +81,31 @@ public class ReservationService {
                         selDate.atStartOfDay(), selDate.atTime(LocalTime.MAX));
 
         //TODO : 당일 예약 수 x timeSet entry 만큼 loop - 성능 개선 필요
-        List<ReservationTimeResponseDto> timeList =
-                ReservationTimetable.TIME_SET.stream().map(
-                                x -> {
-                                    LocalTime startTime = LocalTime.of(x.getStart().getHour(), x.getStart().getMinute());
-                                    LocalTime endTime = LocalTime.of(x.getEnd().getHour(), x.getEnd().getMinute());
-                                    LocalDateTime startDateTime = LocalDateTime.of(selDate, startTime);
-                                    return new ReservationTimeResponseDto(isOccupied(startDateTime, all), startTime, endTime);
-                                })
+        List<ReservationTimeResponse> timeList =
+                ReservationTimetable.TIME_SET.stream().map(x -> getTimeUnitInfo(selDate, x, all))
                         // 07시부터 22시까지 정렬하기 위한 Comparator 구현
                         .sorted(((o1, o2) -> o1.getStart().isAfter(o2.getStart()) ? 1 :
                                 o1.getStart().isBefore(o2.getStart()) ? -1 : 0))
                         .toList();
 
-        return new ReservationTimetableResponseDto(meetingRoom.getId(), meetingRoom.getLocationName(), timeList);
+        return new ReservationTimetableResponse(meetingRoom.getId(), meetingRoom.getLocationName(), timeList);
+    }
+
+    // TIME_SET 시간 단위의 예약 가능 정보, 시각을 얻는 메서드
+    ReservationTimeResponse getTimeUnitInfo(LocalDate selDate, TimeUnit timeUnit, List<Reservation> all){
+        LocalTime startTime = LocalTime.of(timeUnit.getStart().getHour(), timeUnit.getStart().getMinute());
+        LocalTime endTime = LocalTime.of(timeUnit.getEnd().getHour(), timeUnit.getEnd().getMinute());
+        LocalDateTime startDateTime = LocalDateTime.of(selDate, startTime);
+        return new ReservationTimeResponse(isImpossible(startDateTime, all), startTime, endTime);
     }
 
     // 예약의 시작시간에 해당하는 타임은 true 반환
-    boolean isOccupied(LocalDateTime time, List<Reservation> all) {
+    boolean isImpossible(LocalDateTime time, List<Reservation> all) {
+        // 오늘 이전 시각은 항상 예약 불가
+        if (time.toLocalDate().isBefore(LocalDate.now())) {
+            return true;
+        }
+
         for (Reservation reservation : all) {
             LocalDateTime start = reservation.getStartTime();
             LocalDateTime end = reservation.getEndTime();
@@ -120,20 +116,21 @@ public class ReservationService {
         return false;
     }
 
+
     /**
      * 회의실 예약 등록
      */
     @Transactional
     @CacheEvict(cacheNames = {"SpaceResponseDtoList", "FloorResponseDtoList"}, allEntries = true)
-    public ReservationResponseDto addReservation(Long meetingRoomId,
-                                                 ReservationRequestDto requestDto,
-                                                 UserDetailsImpl userDetails) {
+    public ReservationResponse addReservation(Long meetingRoomId,
+                                              ReservationRequest request,
+                                              UserDetailsImpl userDetails) {
         Mr meetingRoom = meetingRoomRepository.findById(meetingRoomId).orElseThrow(
                 () -> new ReservationException(ReservationErrorCode.MEETING_ROOM_NOT_FOUND));
 
         User organizer = userDetails.getUser(); // 회의 주최자
 
-        List<LocalDateTime> list = requestDto.getStartList().stream().map(ReservationTime::getStart)
+        List<LocalDateTime> list = request.getStartList().stream().map(ReservationTime::getStart)
                 .sorted().toList();
         LocalDateTime start = list.get(0);
         LocalDateTime end = list.get(list.size() - 1).plusMinutes(59);
@@ -156,12 +153,12 @@ public class ReservationService {
         reservationRepository.save(reservation);
 
         //TODO: valid 추가
-        if (requestDto.getUserList() == null) {
-            return new ReservationResponseDto(reservation);
+        if (request.getUserList() == null) {
+            return new ReservationResponse(reservation);
         }
 
         // userList id -> User mapping
-        List<Long> ids = requestDto.getUserList().stream().mapToLong(ReservationAttendee::getUserId).boxed().toList();
+        List<Long> ids = request.getUserList().stream().mapToLong(ReservationAttendee::getUserId).boxed().toList();
         List<User> attendee = userRepository.findAllByIdInAndCompanies_CompanyName(ids, organizer.getCompanies().getCompanyName());
 
         // 참석자 리스트와 예약 정보를 ReservationUser 연결 테이블에 저장
@@ -171,17 +168,17 @@ public class ReservationService {
         // 모든 참석자의 스케줄에 회의 일정 추가
         List<Schedule> schedules = info.stream().map(x -> new Schedule(x.getReservation(), x.getAttendee())).toList();
         scheduleRepository.saveAll(schedules);
-        return new ReservationResponseDto(reservation, attendee.stream()
-                .map(x -> new UsernameResponseDto(x.getUsername())).toList());
+        return new ReservationResponse(reservation, attendee.stream()
+                .map(x -> new UsernameResponse(x.getUsername())).toList());
     }
 
     /**
      * 예약 수정 - 시간 변경
      */
     @Transactional
-    public ReservationResponseDto editReservation(Long reservationId,
-                                                  ReservationRequestDto requestDto,
-                                                  UserDetailsImpl userDetails) {
+    public ReservationResponse editReservation(Long reservationId,
+                                               ReservationRequest request,
+                                               UserDetailsImpl userDetails) {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
@@ -190,7 +187,7 @@ public class ReservationService {
             throw new ReservationException(ReservationErrorCode.INVALID_USER_RESERVATION_UPDATE);
         }
 
-        List<LocalDateTime> list = requestDto.getStartList().stream().map(ReservationTime::getStart)
+        List<LocalDateTime> list = request.getStartList().stream().map(ReservationTime::getStart)
                 .sorted().toList();
         LocalDateTime start = list.get(0);
         LocalDateTime end = list.get(list.size() - 1).plusMinutes(59);
@@ -210,7 +207,7 @@ public class ReservationService {
 
         reservation.update(start, end);
 
-        return new ReservationResponseDto(reservation);
+        return new ReservationResponse(reservation);
     }
 
     @Transactional

--- a/src/main/java/com/example/chillisauce/reservations/service/UserReservationService.java
+++ b/src/main/java/com/example/chillisauce/reservations/service/UserReservationService.java
@@ -1,9 +1,9 @@
 package com.example.chillisauce.reservations.service;
 
 import com.example.chillisauce.reservations.dto.ReservationUserWrapper;
-import com.example.chillisauce.reservations.dto.response.UserReservationListResponseDto;
-import com.example.chillisauce.reservations.dto.response.UserReservationResponseDto;
-import com.example.chillisauce.reservations.dto.response.UsernameResponseDto;
+import com.example.chillisauce.reservations.dto.response.UserReservationListResponse;
+import com.example.chillisauce.reservations.dto.response.UserReservationResponse;
+import com.example.chillisauce.reservations.dto.response.UsernameResponse;
 import com.example.chillisauce.reservations.entity.Reservation;
 import com.example.chillisauce.reservations.repository.ReservationRepository;
 import com.example.chillisauce.reservations.repository.ReservationUserRepository;
@@ -28,21 +28,21 @@ public class UserReservationService {
      * 특정 유저의 예약 내역 조회
      */
     @Transactional(readOnly = true)
-    public UserReservationListResponseDto getUserReservations(UserDetailsImpl userDetails) {
+    public UserReservationListResponse getUserReservations(UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         List<Reservation> reservations = reservationRepository.findAllByUserId(user.getId());
         List<Long> ids = reservations.stream().mapToLong(Reservation::getId).boxed().toList();
 
         List<ReservationUserWrapper> linkList = reservationUserRepository.findReservationUserByReservationIdIn(ids);
 
-        return new UserReservationListResponseDto(reservations.stream().map(x -> {
+        return new UserReservationListResponse(reservations.stream().map(x -> {
             Mr m = x.getMeetingRoom();
             User u = x.getUser();
             Long mrId = m == null ? 0 : m.getId();
             String username = u == null ? "탈퇴한 유저" : user.getUsername();
-            List<UsernameResponseDto> userList = linkList.stream().filter(y -> y.getReservationId().equals(x.getId()))
-                    .map(UsernameResponseDto::new).toList();
-            return new UserReservationResponseDto(x, mrId, username, userList);
+            List<UsernameResponse> userList = linkList.stream().filter(y -> y.getReservationId().equals(x.getId()))
+                    .map(UsernameResponse::new).toList();
+            return new UserReservationResponse(x, mrId, username, userList);
         }).toList());
     }
 }

--- a/src/main/java/com/example/chillisauce/spaces/dto/MrResponseDto.java
+++ b/src/main/java/com/example/chillisauce/spaces/dto/MrResponseDto.java
@@ -1,11 +1,9 @@
 package com.example.chillisauce.spaces.dto;
 
-import com.example.chillisauce.reservations.dto.response.ReservationResponseDto;
+import com.example.chillisauce.reservations.dto.response.ReservationResponse;
 import com.example.chillisauce.spaces.entity.Mr;
-import com.example.chillisauce.spaces.entity.UserLocation;
 import lombok.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,14 +19,14 @@ public class MrResponseDto {
 
     private String y;
 
-    private List<ReservationResponseDto> reservationList;
+    private List<ReservationResponse> reservationList;
 
     public MrResponseDto(Mr mr) {
         this.mrId = mr.getId();
         this.mrName = mr.getLocationName();
         this.x = mr.getX();
         this.y = mr.getY();
-        this.reservationList =mr.getReservations().stream().map(ReservationResponseDto::new).collect(Collectors.toList());
+        this.reservationList =mr.getReservations().stream().map(ReservationResponse::new).collect(Collectors.toList());
     }
 
     public MrResponseDto(Long id, String mrName, String x, String y) {

--- a/src/main/java/com/example/chillisauce/spaces/service/MrService.java
+++ b/src/main/java/com/example/chillisauce/spaces/service/MrService.java
@@ -1,6 +1,5 @@
 package com.example.chillisauce.spaces.service;
 
-import com.example.chillisauce.reservations.dto.response.ReservationResponseDto;
 import com.example.chillisauce.reservations.service.ReservationService;
 import com.example.chillisauce.security.UserDetailsImpl;
 import com.example.chillisauce.spaces.dto.MrRequestDto;
@@ -18,7 +17,6 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/test/java/com/example/chillisauce/reservations/controller/ReservationControllerTest.java
+++ b/src/test/java/com/example/chillisauce/reservations/controller/ReservationControllerTest.java
@@ -1,7 +1,7 @@
 package com.example.chillisauce.reservations.controller;
 
 import com.example.chillisauce.message.ResponseMessage;
-import com.example.chillisauce.reservations.dto.request.ReservationRequestDto;
+import com.example.chillisauce.reservations.dto.request.ReservationRequest;
 import com.example.chillisauce.reservations.dto.request.ReservationTime;
 import com.example.chillisauce.reservations.dto.request.ReservationAttendee;
 import com.example.chillisauce.reservations.dto.response.*;
@@ -79,7 +79,7 @@ class ReservationControllerTest {
         @WithMockUser
         void 전체_회의실_예약내역을_반환한다() throws Exception {
             // given
-            ReservationListResponseDto all = getAllReservationResponse();
+            ReservationListResponse all = getAllReservationResponse();
             when(reservationService.getAllReservations(eq(companyName), any())).thenReturn(all);
 
             // when
@@ -108,9 +108,9 @@ class ReservationControllerTest {
                     ));
         }
 
-        private ReservationListResponseDto getAllReservationResponse() {
-            List<ReservationDetailResponseDto> responseList = new ArrayList<>();
-            ReservationDetailResponseDto reservationOne = ReservationDetailResponseDto.builder()
+        private ReservationListResponse getAllReservationResponse() {
+            List<ReservationDetailResponse> responseList = new ArrayList<>();
+            ReservationDetailResponse reservationOne = ReservationDetailResponse.builder()
                     .reservationId(1L)
                     .username("강백호")
                     .mrId(1L)
@@ -119,7 +119,7 @@ class ReservationControllerTest {
                     .end(LocalDateTime.of(2023, 4, 11, 15, 59))
                     .build();
 
-            ReservationDetailResponseDto reservationTwo = ReservationDetailResponseDto.builder()
+            ReservationDetailResponse reservationTwo = ReservationDetailResponse.builder()
                     .reservationId(2L)
                     .username("윤대협")
                     .mrId(3L)
@@ -130,7 +130,7 @@ class ReservationControllerTest {
 
             responseList.add(reservationOne);
             responseList.add(reservationTwo);
-            return new ReservationListResponseDto(responseList);
+            return new ReservationListResponse(responseList);
         }
 
         @Test
@@ -146,7 +146,7 @@ class ReservationControllerTest {
     class GetReservationTimeTableTestCase {
         // given
         String url = "/reservations/1";
-        ReservationTimetableResponseDto timeTable = getReservationTimetable();
+        ReservationTimetableResponse timeTable = getReservationTimetable();
         @Test
         @WithMockUser
         void 특정날짜_특정회의실의_예약테이블을_반환한다() throws Exception {
@@ -179,26 +179,26 @@ class ReservationControllerTest {
                     ));
         }
 
-        private ReservationTimetableResponseDto getReservationTimetable() {
+        private ReservationTimetableResponse getReservationTimetable() {
             Long mrId = 1L;
             String mrName = "testMeetingRoom";
-            ReservationTimeResponseDto timeOne = ReservationTimeResponseDto.builder().isCheckOut(false)
+            ReservationTimeResponse timeOne = ReservationTimeResponse.builder().isCheckOut(false)
                     .start(LocalTime.of(7, 0))
                     .end(LocalTime.of(7, 59))
                     .build();
 
-            ReservationTimeResponseDto timeTwo = ReservationTimeResponseDto.builder().isCheckOut(true)
+            ReservationTimeResponse timeTwo = ReservationTimeResponse.builder().isCheckOut(true)
                     .start(LocalTime.of(8, 0))
                     .end(LocalTime.of(8, 59))
                     .build();
 
-            ReservationTimeResponseDto timeLast = ReservationTimeResponseDto.builder()
+            ReservationTimeResponse timeLast = ReservationTimeResponse.builder()
                     .isCheckOut(false)
                     .start(LocalTime.of(22, 0))
                     .end(LocalTime.of(22, 59))
                     .build();
 
-            return new ReservationTimetableResponseDto(mrId, mrName, List.of(timeOne, timeTwo, timeLast));
+            return new ReservationTimetableResponse(mrId, mrName, List.of(timeOne, timeTwo, timeLast));
         }
     }
 
@@ -215,8 +215,8 @@ class ReservationControllerTest {
         ReservationAttendee userOne = new ReservationAttendee(1L);
         ReservationAttendee userTwo = new ReservationAttendee(2L);
         List<ReservationAttendee> userList = List.of(userOne, userTwo);
-        ReservationRequestDto requestBody = new ReservationRequestDto(List.of(requestOne, requestTwo), userList);
-        ReservationResponseDto response = new ReservationResponseDto(startOne, end, new ArrayList<>());
+        ReservationRequest requestBody = new ReservationRequest(List.of(requestOne, requestTwo), userList);
+        ReservationResponse response = new ReservationResponse(startOne, end, new ArrayList<>());
 
         @Test
         @WithMockUser
@@ -297,8 +297,8 @@ class ReservationControllerTest {
         ReservationAttendee userOne = new ReservationAttendee(1L);
         ReservationAttendee userTwo = new ReservationAttendee(2L);
         List<ReservationAttendee> userList = List.of(userOne, userTwo);
-        ReservationRequestDto requestBody = new ReservationRequestDto(List.of(requestOne, requestTwo), userList);
-        ReservationResponseDto response = new ReservationResponseDto(startOne, end, new ArrayList<>());
+        ReservationRequest requestBody = new ReservationRequest(List.of(requestOne, requestTwo), userList);
+        ReservationResponse response = new ReservationResponse(startOne, end, new ArrayList<>());
 
         @Test
         @WithMockUser

--- a/src/test/java/com/example/chillisauce/reservations/controller/UserReservationControllerTest.java
+++ b/src/test/java/com/example/chillisauce/reservations/controller/UserReservationControllerTest.java
@@ -1,10 +1,9 @@
 package com.example.chillisauce.reservations.controller;
 
-import com.example.chillisauce.reservations.dto.response.UserReservationListResponseDto;
-import com.example.chillisauce.reservations.dto.response.UserReservationResponseDto;
-import com.example.chillisauce.reservations.dto.response.UsernameResponseDto;
+import com.example.chillisauce.reservations.dto.response.UserReservationListResponse;
+import com.example.chillisauce.reservations.dto.response.UserReservationResponse;
+import com.example.chillisauce.reservations.dto.response.UsernameResponse;
 import com.example.chillisauce.reservations.exception.ReservationExceptionHandler;
-import com.example.chillisauce.reservations.service.ReservationService;
 import com.example.chillisauce.reservations.service.UserReservationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -31,7 +30,6 @@ import java.util.List;
 
 import static com.example.chillisauce.docs.ApiDocumentUtil.getDocumentRequest;
 import static com.example.chillisauce.docs.ApiDocumentUtil.getDocumentResponse;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -68,22 +66,22 @@ class UserReservationControllerTest {
         // given
         String url = "/users/reservations";
 
-        UserReservationResponseDto reservationOne = UserReservationResponseDto.builder()
+        UserReservationResponse reservationOne = UserReservationResponse.builder()
                 .mrId(1L)
                 .mrName("회의실1")
                 .reservationId(1L)
                 .username("김철수")
-                .userList(List.of(new UsernameResponseDto("홍길동"), new UsernameResponseDto("임꺽정")))
+                .userList(List.of(new UsernameResponse("홍길동"), new UsernameResponse("임꺽정")))
                 .start(LocalDateTime.of(2023, 4, 28, 15, 0))
                 .end(LocalDateTime.of(2023, 4, 28, 15, 59))
                 .build();
 
-        UserReservationResponseDto reservationTwo = UserReservationResponseDto.builder()
+        UserReservationResponse reservationTwo = UserReservationResponse.builder()
                 .mrId(2L)
                 .mrName("회의실2")
                 .reservationId(2L)
                 .username("김철수")
-                .userList(List.of(new UsernameResponseDto("채소연"), new UsernameResponseDto("성춘향")))
+                .userList(List.of(new UsernameResponse("채소연"), new UsernameResponse("성춘향")))
                 .start(LocalDateTime.of(2023, 4, 29, 16, 0))
                 .end(LocalDateTime.of(2023, 4, 29, 16, 59))
                 .build();
@@ -92,7 +90,7 @@ class UserReservationControllerTest {
         @WithMockUser
         void 회원의_회의실_예약내역을_반환한다() throws Exception {
             // given
-            UserReservationListResponseDto response = new UserReservationListResponseDto(List.of(reservationOne, reservationTwo));
+            UserReservationListResponse response = new UserReservationListResponse(List.of(reservationOne, reservationTwo));
             when(userReservationService.getUserReservations(any())).thenReturn(response);
 
             // when

--- a/src/test/java/com/example/chillisauce/reservations/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/example/chillisauce/reservations/repository/ReservationRepositoryTest.java
@@ -1,9 +1,6 @@
 package com.example.chillisauce.reservations.repository;
 
 import com.example.chillisauce.config.TestConfig;
-import com.example.chillisauce.reservations.dto.request.ReservationRequestDto;
-import com.example.chillisauce.reservations.dto.request.ReservationTime;
-import com.example.chillisauce.reservations.dto.response.ReservationResponseDto;
 import com.example.chillisauce.reservations.entity.Reservation;
 import com.example.chillisauce.spaces.repository.MrRepository;
 import com.example.chillisauce.spaces.repository.SpaceRepository;
@@ -14,26 +11,18 @@ import com.example.chillisauce.users.entity.User;
 import com.example.chillisauce.users.entity.UserRoleEnum;
 import com.example.chillisauce.users.repository.CompanyRepository;
 import com.example.chillisauce.users.repository.UserRepository;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -41,7 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest

--- a/src/test/java/com/example/chillisauce/reservations/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/chillisauce/reservations/service/ReservationServiceTest.java
@@ -1,17 +1,16 @@
 package com.example.chillisauce.reservations.service;
 
 import com.example.chillisauce.reservations.dto.request.ReservationAttendee;
-import com.example.chillisauce.reservations.dto.request.ReservationRequestDto;
+import com.example.chillisauce.reservations.dto.request.ReservationRequest;
 import com.example.chillisauce.reservations.dto.request.ReservationTime;
-import com.example.chillisauce.reservations.dto.response.ReservationListResponseDto;
-import com.example.chillisauce.reservations.dto.response.ReservationResponseDto;
-import com.example.chillisauce.reservations.dto.response.ReservationTimetableResponseDto;
+import com.example.chillisauce.reservations.dto.response.ReservationListResponse;
+import com.example.chillisauce.reservations.dto.response.ReservationResponse;
+import com.example.chillisauce.reservations.dto.response.ReservationTimetableResponse;
 import com.example.chillisauce.reservations.entity.Reservation;
 import com.example.chillisauce.reservations.exception.ReservationException;
 import com.example.chillisauce.reservations.repository.ReservationRepository;
 import com.example.chillisauce.reservations.repository.ReservationUserRepository;
 import com.example.chillisauce.reservations.vo.ReservationTimetable;
-import com.example.chillisauce.schedules.exception.ScheduleException;
 import com.example.chillisauce.schedules.repository.ScheduleRepository;
 import com.example.chillisauce.security.UserDetailsImpl;
 import com.example.chillisauce.spaces.entity.Mr;
@@ -87,7 +86,7 @@ class ReservationServiceTest {
             when(reservationRepository.findAll()).thenReturn(List.of(reservationOne, reservationTwo));
 
             // when
-            ReservationListResponseDto result = reservationService.getAllReservations(company.getCompanyName(), userDetails);
+            ReservationListResponse result = reservationService.getAllReservations(company.getCompanyName(), userDetails);
 
             // then
             assertThat(result.getReservationList().size()).isEqualTo(size);
@@ -123,7 +122,7 @@ class ReservationServiceTest {
                     .thenReturn(List.of(reservationOne, reservationTwo));
 
             // when
-            ReservationTimetableResponseDto result =
+            ReservationTimetableResponse result =
                     reservationService.getReservationTimetable(selDate, meetingRoom.getId(), userDetails);
 
             // then
@@ -141,7 +140,7 @@ class ReservationServiceTest {
             when(meetingRoomRepository.findById(meetingRoom.getId())).thenReturn(Optional.of(meetingRoom));
 
             // when
-            ReservationTimetableResponseDto result = reservationService.getReservationTimetable(selDate, meetingRoom.getId(), userDetails);
+            ReservationTimetableResponse result = reservationService.getReservationTimetable(selDate, meetingRoom.getId(), userDetails);
 
             // then
             assertThat(result.getTimeList())
@@ -162,7 +161,7 @@ class ReservationServiceTest {
         ReservationTime selectTime = new ReservationTime(LocalDateTime.of(2023, 4, 8, 12, 0));
         List<ReservationTime> startList = List.of(selectTime);
         List<ReservationAttendee> userList = List.of(new ReservationAttendee(organizer.getId()), new ReservationAttendee(attendee.getId()));
-        ReservationRequestDto requestDto = new ReservationRequestDto(startList, userList);
+        ReservationRequest requestDto = new ReservationRequest(startList, userList);
 
         @Test
         void 예약을_등록한다() {
@@ -172,7 +171,7 @@ class ReservationServiceTest {
             // when
             when(meetingRoomRepository.findById(eq(meetingRoom.getId()))).thenReturn(Optional.of(meetingRoom));
 
-            ReservationResponseDto result = reservationService.addReservation(meetingRoom.getId(), requestDto, userDetails);
+            ReservationResponse result = reservationService.addReservation(meetingRoom.getId(), requestDto, userDetails);
 
             // then
             assertThat(result).isNotNull();
@@ -189,7 +188,7 @@ class ReservationServiceTest {
             Reservation firstReservation = Reservation_생성(organizer, meetingRoom,
                     secondSelectTime.getStart(), secondSelectTime.getStart().plusMinutes(59));
 
-            ReservationRequestDto secondReservationDto = new ReservationRequestDto(list, userList);
+            ReservationRequest secondReservationDto = new ReservationRequest(list, userList);
 
             when(meetingRoomRepository.findById(any(Long.class))).thenReturn(Optional.of(meetingRoom));
 
@@ -241,12 +240,12 @@ class ReservationServiceTest {
             ReservationAttendee userOne = new ReservationAttendee(1L);
             ReservationAttendee userTwo = new ReservationAttendee(2L);
             List<ReservationAttendee> userList = List.of(userOne, userTwo);
-            ReservationRequestDto request = new ReservationRequestDto(startList, userList);
+            ReservationRequest request = new ReservationRequest(startList, userList);
 
             // when
             when(reservationRepository.findById(eq(before.getId()))).thenReturn(Optional.of(before));
 
-            ReservationResponseDto result = reservationService.editReservation(before.getId(), request, userDetails);
+            ReservationResponse result = reservationService.editReservation(before.getId(), request, userDetails);
 
             // then
             assertThat(result).isNotNull();

--- a/src/test/java/com/example/chillisauce/reservations/service/UserReservationServiceTest.java
+++ b/src/test/java/com/example/chillisauce/reservations/service/UserReservationServiceTest.java
@@ -1,6 +1,6 @@
 package com.example.chillisauce.reservations.service;
 
-import com.example.chillisauce.reservations.dto.response.UserReservationListResponseDto;
+import com.example.chillisauce.reservations.dto.response.UserReservationListResponse;
 import com.example.chillisauce.reservations.entity.Reservation;
 import com.example.chillisauce.reservations.entity.ReservationUser;
 import com.example.chillisauce.reservations.repository.ReservationRepository;
@@ -68,7 +68,7 @@ class UserReservationServiceTest {
                     .thenReturn(List.of(reservationOne, reservationTwo));
 
             // when
-            UserReservationListResponseDto result = userReservationService.getUserReservations(userDetails);
+            UserReservationListResponse result = userReservationService.getUserReservations(userDetails);
 
             // then
             assertThat(result.getReservationList().size()).isEqualTo(2);

--- a/src/test/java/com/example/chillisauce/spaces/controller/MrControllerTest.java
+++ b/src/test/java/com/example/chillisauce/spaces/controller/MrControllerTest.java
@@ -1,8 +1,6 @@
 package com.example.chillisauce.spaces.controller;
 
-import com.example.chillisauce.reservations.dto.response.ReservationResponseDto;
-import com.example.chillisauce.spaces.dto.BoxRequestDto;
-import com.example.chillisauce.spaces.dto.BoxResponseDto;
+import com.example.chillisauce.reservations.dto.response.ReservationResponse;
 import com.example.chillisauce.spaces.dto.MrRequestDto;
 import com.example.chillisauce.spaces.dto.MrResponseDto;
 import com.example.chillisauce.spaces.service.MrService;
@@ -178,7 +176,7 @@ public class MrControllerTest {
             String companyName = "testCompany";
             String url = "/mr/" + companyName;
             List<MrResponseDto> mrResponseDtoList = new ArrayList<>();
-            List<ReservationResponseDto> reservationList = new ArrayList<>();
+            List<ReservationResponse> reservationList = new ArrayList<>();
             mrResponseDtoList.add(new MrResponseDto(1L,"Mr 테스트 생성", "777" , "888", reservationList));
 
             when(mrService.mrlist(eq(companyName), any())).thenReturn(mrResponseDtoList);


### PR DESCRIPTION
전송객체인 dto의 변수 이름이 지나치게 길어 클래스 이름을 줄이려고 'dto'를 삭제했습니다.
예약 도메인에서 타임테이블을 조회하는 메서드를 리팩터링했습니다.