### PR TITLE
test : 유저검색 Querydsl 변경

### DIFF
--- a/src/main/java/com/example/chillisauce/users/repository/UserRepository.java
+++ b/src/main/java/com/example/chillisauce/users/repository/UserRepository.java
@@ -16,9 +16,9 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     List<User> findAllByIdInAndCompanies_CompanyName(List<Long> userIds, String companyName);
 
-    @Query("select u " +
-            "from users u " +
-            "join fetch u.companies " +
-            "where u.username like %:name%")
-    List<User> findAllByUsernameContainingAndCompanies(@Param("name") String name);
+//    @Query("select u " +
+//            "from users u " +
+//            "join fetch u.companies " +
+//            "where u.username like %:name%")
+//    List<User> findAllByUsernameContainingAndCompanies(@Param("name") String name);
 }

--- a/src/main/java/com/example/chillisauce/users/repository/UserRepositorySupport.java
+++ b/src/main/java/com/example/chillisauce/users/repository/UserRepositorySupport.java
@@ -1,6 +1,7 @@
 package com.example.chillisauce.users.repository;
 
 import com.example.chillisauce.users.entity.User;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -8,4 +9,5 @@ import java.util.Optional;
 public interface UserRepositorySupport {
     Optional<User> findByIdAndCompanies_CompanyName (Long id, String companyName);
     List<User> findAllByCompanies_CompanyName (String companyName);
+    List<User> findAllByUsernameContainingAndCompanies(String name, String companyName);    //검색
 }

--- a/src/main/java/com/example/chillisauce/users/service/SearchService.java
+++ b/src/main/java/com/example/chillisauce/users/service/SearchService.java
@@ -2,7 +2,11 @@ package com.example.chillisauce.users.service;
 
 import com.example.chillisauce.security.UserDetailsImpl;
 import com.example.chillisauce.users.dto.response.UserDetailResponseDto;
+import com.example.chillisauce.users.entity.Companies;
 import com.example.chillisauce.users.entity.User;
+import com.example.chillisauce.users.exception.UserErrorCode;
+import com.example.chillisauce.users.exception.UserException;
+import com.example.chillisauce.users.repository.CompanyRepository;
 import com.example.chillisauce.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,10 +21,13 @@ public class SearchService {
     private final UserRepository userRepository;
 
     public List<UserDetailResponseDto> searchUser(String name, UserDetailsImpl userDetails) {
-        log.info("search user");
         User finder = userDetails.getUser();
         String companyName = finder.getCompanies().getCompanyName();
-        List<User> users = userRepository.findAllByUsernameContainingAndCompanies(name);
+        List<User> users = userRepository.findAllByUsernameContainingAndCompanies(name, companyName);
+
+        if (users.isEmpty()) {
+            throw new UserException(UserErrorCode.USER_NOT_FOUND);
+        }
         return users.stream().map(UserDetailResponseDto::new).toList();
     }
 }

--- a/src/test/java/com/example/chillisauce/users/service/SearchServiceTest.java
+++ b/src/test/java/com/example/chillisauce/users/service/SearchServiceTest.java
@@ -43,7 +43,7 @@ class SearchServiceTest {
         @Test
         void 문자열에_포함된_유저를_반환한다() {
             // given
-            when(userRepository.findAllByUsernameContainingAndCompanies(eq(query)))
+            when(userRepository.findAllByUsernameContainingAndCompanies(eq(query), eq(company.getCompanyName())))
                     .thenReturn(List.of(findOne, findTwo));
 
             // when


### PR DESCRIPTION
유저검색기능의 성능을 개선하기 위해 기존로직인 JPQL에서 QueryDSL로 쿼리를 전환합니다.
자신의 회사의 사원만 검색이 가능하도록 company를 검증하는 로직을 추가하였습니다.